### PR TITLE
Update docs and env template for webhook kill feed

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -51,14 +51,16 @@ LOG_CHANNEL_ID=0
 # KILL FEED / TANK TRACKING (EXPERIMENTAL)
 # =============================================================================
 
-# Enable CRCON WebSocket kill feed integration (true/false)
+# Enable CRCON kill feed integration (true/false)
 ENABLE_KILL_FEED=false
 
-# CRCON WebSocket endpoint for log streaming (required when ENABLE_KILL_FEED=true)
-CRCON_WS_URL=ws://localhost:8010/ws/logs
+# Webhook listener settings (used by CRCON kill webhook)
+KILL_WEBHOOK_HOST=0.0.0.0
+KILL_WEBHOOK_PORT=8081
+KILL_WEBHOOK_PATH=/kill-webhook
 
-# Bearer token for the CRCON WebSocket log stream. Leave blank to reuse CRCON_API_KEY.
-CRCON_WS_TOKEN=
+# Optional shared secret; if set, CRCON must send X-Webhook-Secret with this value
+KILL_WEBHOOK_SECRET=
 
 # Optional JSON mapping (or file path) defining which weapon keywords count as tank kills
 # Example: {"cannon_shells":["75mm","88mm"],"launchers":["bazooka","panzerschreck"]}

--- a/README.md
+++ b/README.md
@@ -214,28 +214,17 @@ Make sure to include `http://` or `https://`
 
 ## 🧪 Diagnostics & Manual Testing
 
-Need to validate the tank kill overlay without a production server? Use the mock WebSocket helper:
+Need to validate the tank kill overlay without a production server? Use a local webhook POST:
 
-1. Install the lightweight dev dependency (ignored by git):
+1) Start the bot locally with `ENABLE_KILL_FEED=true` (defaults: `KILL_WEBHOOK_PORT=8081`, `KILL_WEBHOOK_PATH=/kill-webhook`).
+2) Send a test kill payload:
    ```bash
-   npm install ws
+   curl -X POST http://localhost:8081/kill-webhook \
+     -H "Content-Type: application/json" \
+     -d '{"killer_team":"allies","victim_team":"axis","weapon":"75mm","killer_name":"Allied Gunner","victim_name":"Axis Tank","vehicle":"Panzer IV"}'
    ```
-2. Start the mock feed (defaults shown):
-   ```bash
-   node tools/mock_kill_feed_server.js --port 8765 --token local-dev
-   ```
-   - Press **ENTER** to emit the next canned tank kill
-   - Or paste raw JSON (one line) to broadcast custom payloads
-3. Point the bot at the mock feed in `.env`:
-   ```env
-   ENABLE_KILL_FEED=true
-   CRCON_WS_URL=ws://localhost:8765
-   CRCON_WS_TOKEN=local-dev  # leave blank to reuse CRCON_API_KEY
-   ```
-4. Run `python enhanced_discord_bot.py`, fire `/reverse_clock`, and start a match.
-5. Use `/killfeed_status` to confirm the listener is connected, then trigger sample kills from the mock terminal—tank counts should update immediately in the embed, CRCON broadcasts, and log output.
-
-Set `AUTO_INTERVAL=3000 node tools/mock_kill_feed_server.js` to continuously stream test kills while iterating on UI.
+   Include `-H "X-Webhook-Secret: <value>"` if you set `KILL_WEBHOOK_SECRET`.
+3) Run `/killfeed_status` to confirm the webhook listener is running and the last event is captured.
 
 ## 🏆 How It Works
 
@@ -272,9 +261,9 @@ Set `AUTO_INTERVAL=3000 node tools/mock_kill_feed_server.js` to continuously str
 - Use `/crcon_status` or `/test_map` for live diagnostics
 
 **Kill feed disabled or not updating:**
-- Ensure `ENABLE_KILL_FEED=true` plus valid `CRCON_WS_URL`/`CRCON_WS_TOKEN`
+- Ensure `ENABLE_KILL_FEED=true`, CRCON webhook URL points to your deployed listener, and secrets match
 - Start a match via `/reverse_clock` so the listener attaches to an active channel
-- Run `/killfeed_status` to confirm the WebSocket connection and inspect the latest event
+- Run `/killfeed_status` to confirm the webhook listener and inspect the latest event
 
 **Auto-switch not working:**
 - Set `CRCON_AUTO_SWITCH=true`


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Replace WebSocket-based kill feed with webhook listener architecture

- Add webhook configuration variables for host, port, path, and secret

- Update testing documentation from mock WebSocket to curl-based webhook testing

- Simplify kill feed setup and troubleshooting guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocket Integration<br/>CRCON_WS_URL/TOKEN"] -->|"Replace with"| B["Webhook Listener<br/>KILL_WEBHOOK_*"]
  B -->|"Simplifies"| C["Testing & Docs"]
  C -->|"Updates"| D["README & SETUP"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.template</strong><dd><code>Replace WebSocket config with webhook listener variables</code>&nbsp; </dd></summary>
<hr>

.env.template

<ul><li>Replaced <code>CRCON_WS_URL</code> and <code>CRCON_WS_TOKEN</code> with webhook configuration <br>variables<br> <li> Added <code>KILL_WEBHOOK_HOST</code>, <code>KILL_WEBHOOK_PORT</code>, <code>KILL_WEBHOOK_PATH</code> for <br>listener setup<br> <li> Added <code>KILL_WEBHOOK_SECRET</code> for optional authentication<br> <li> Updated comments to reflect webhook-based architecture instead of <br>WebSocket</ul>


</details>


  </td>
  <td><a href="https://github.com/gbone001/HLL-Tank-Overwatch/pull/9/files#diff-749e06f64632f62a0c0dfbf4c4f3850e27e94ac109aa121fabd5c29469ae88de">+15/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update testing docs from WebSocket to webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Replaced mock WebSocket server testing section with simple curl-based <br>webhook testing<br> <li> Updated diagnostics to use HTTP POST requests instead of WebSocket <br>connections<br> <li> Simplified troubleshooting guidance for kill feed to reference webhook <br>configuration<br> <li> Removed references to <code>mock_kill_feed_server.js</code> and npm WebSocket <br>dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/gbone001/HLL-Tank-Overwatch/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+17/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SETUP.md</strong><dd><code>Document webhook listener configuration and testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SETUP.md

<ul><li>Replaced <code>CRCON_WS_URL</code> and <code>CRCON_WS_TOKEN</code> documentation with webhook <br>listener variables<br> <li> Added table entries for <code>KILL_WEBHOOK_HOST</code>, <code>KILL_WEBHOOK_PORT</code>, <br><code>KILL_WEBHOOK_PATH</code>, <code>KILL_WEBHOOK_SECRET</code><br> <li> Replaced "Local Kill Feed Mock" section with webhook-based testing <br>instructions using curl<br> <li> Updated troubleshooting to reference webhook configuration instead of <br>WebSocket settings</ul>


</details>


  </td>
  <td><a href="https://github.com/gbone001/HLL-Tank-Overwatch/pull/9/files#diff-0040e607148899aef28b61411ebc22c4266046b5035b7bd2a45424ff2027521f">+21/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

